### PR TITLE
Fixed the b64 powershell payload

### DIFF
--- a/index.html
+++ b/index.html
@@ -736,8 +736,6 @@
                     command = rsg.getReverseShellCommand()
                 }
 
-                command = rsg.getReverseShellCommand()
-
                 const encoding = encodingSelect.value;
                 if (encoding === 'Base64') {
                     command = btoa(command)


### PR DESCRIPTION
The b64 command was getting overwritten.

The else block handles the case if it's not the b64 command, but the code was also placed outside of the if-else, essentially rendering that block useless.