### PR TITLE
[Bug] Set Encoding to None when swapping tabs

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -27,27 +27,30 @@
 
         document.querySelector("#reverse-tab").addEventListener("click", () => {
             rsg.setState({
-                commandType: CommandType.ReverseShell
+                commandType: CommandType.ReverseShell,
             });
         })
 
         document.querySelector("#bind-tab").addEventListener("click", () => {
             rsg.setState({
-                commandType: CommandType.BindShell
-            });
+                commandType: CommandType.BindShell,
+            	encoding: "None"
+	    });
         })
 
         document.querySelector("#bind-tab").addEventListener("click", () => {
             document.querySelector("#bind-shell-selection").innerHTML = "";
             rsg.setState({
                 commandType: CommandType.BindShell
+
             });
         })
 
         document.querySelector("#msfvenom-tab").addEventListener("click", () => {
             document.querySelector("#msfvenom-selection").innerHTML = "";
             rsg.setState({
-                commandType: CommandType.MSFVenom
+                commandType: CommandType.MSFVenom,
+		encoding: "None"
             });
         });
 


### PR DESCRIPTION
Hello,

When I was using your website, I noticed a bug when I used the advanced feature for encoding URL. When swapping to msfvenom (with URL encoding on) it would result in the msfvenom command with URL encoding. As shown in the screenshot below.

![image](https://user-images.githubusercontent.com/34222183/147167292-994ba815-8674-4163-b42f-636b47e6c101.png)

Essentially, i just added encoding type to "None" to fix this issue. Otherwise you may just want to put the "Show Advanced" on each one of the tabs! Quick fix, but thought it would be helpful rather than having to continuously switch back to fix it.

Cheers,
Sam
