### PR TITLE
Remove 'p' from nc/netcat listener flags

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -434,14 +434,14 @@ const msfvenomCommands =  withCommandType(
 const rsgData = {
 
     listenerCommands: [
-        ['nc', 'nc -lvnp {port}'],
-        ['ncat', 'ncat -lvnp {port}'],
-        ['ncat (TLS)', 'ncat --ssl -lvnp {port}'],
-        ['rlwrap + nc', 'rlwrap -cAr nc -lvnp {port}'],
+        ['nc', 'nc -lvn {port}'],
+        ['ncat', 'ncat -lvn {port}'],
+        ['ncat (TLS)', 'ncat --ssl -lvn {port}'],
+        ['rlwrap + nc', 'rlwrap -cAr nc -lvn {port}'],
 	['rustcat', 'rcat -lp {port}'],
 	['rustcat + Command History', 'rcat -lHp {port}'],
         ['pwncat', 'python3 -m pwncat -lp {port}'],
-        ['windows ConPty', 'stty raw -echo; (stty size; cat) | nc -lvnp {port}'],
+        ['windows ConPty', 'stty raw -echo; (stty size; cat) | nc -lvn {port}'],
         ['socat', 'socat -d -d TCP-LISTEN:{port} STDOUT'],
         ['socat (TTY)', 'socat -d -d file:`tty`,raw,echo=0 TCP-LISTEN:{port}'],
         ['powercat', 'powercat -l -p {port}'],


### PR DESCRIPTION
The 'p' flag is unnecessary when establishing a Netcat listener. It's used to indicate the source port for when you're *establishing* a connection. For instance, if you used nc -p 53 <ip> you would connect to an IP address with your source port as the default port used for DNS, 53.