### PR TITLE
Added ncat.exe to listeners

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -451,6 +451,7 @@ const rsgData = {
     listenerCommands: [
         ['nc', 'nc -lvnp {port}'],
         ['ncat', 'ncat -lvnp {port}'],
+        ['ncat.exe', 'ncat.exe -lvnp {port}'],
         ['ncat (TLS)', 'ncat --ssl -lvnp {port}'],
         ['rlwrap + nc', 'rlwrap -cAr nc -lvnp {port}'],
 	['rustcat', 'rcat -lp {port}'],


### PR DESCRIPTION
Allows for simple Windows ncat.exe calling from inside of WSL, meaning the listener runs on windows and binds to the windows port and not a NAT'ed WSL host.