### PR TITLE
⚒ Fix IP input max-length

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
                                             <span id="ip-label" class="input-group-text">IP</span>
                                         </div>
                                         <input id="ip" type="text" class="form-control form-control-lg text-center px-1"
-                                            size="12VW" maxlength="15" aria-label="IP"
+                                            size="12VW" aria-label="IP"
                                             aria-describedby="ip-label">
                                     </div>
                                 </div>


### PR DESCRIPTION
Due to the `max-length` attribute ngrok's TCP IP (Domain) can't be used because it's 17+- characters long.
I don't see much of a use for the max-length attribute as somepeople might be using tunnels and those mostly are long.
![image](https://user-images.githubusercontent.com/20037329/229303636-b9ce8f35-a2e7-482c-a262-e1cbf6221bd7.png)
