### PR TITLE
⚒ Fix Self-XSS #131

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -115,7 +115,7 @@ const fixedEncodeURIComponent = function (str) {
 }
 
 const rsg = {
-    ip: query.get('ip') || localStorage.getItem('ip') || '10.10.10.10',
+    ip: (query.get('ip') || localStorage.getItem('ip') || '10.10.10.10').replace(/[^a-zA-Z0-9.\-]/g, ''),
     port: query.get('port') || localStorage.getItem('port') || 9001,
     payload: query.get('payload') || localStorage.getItem('payload') || 'windows/x64/meterpreter/reverse_tcp',
     payload: query.get('type') || localStorage.getItem('type') || 'cmd-curl',


### PR DESCRIPTION
I've only allowed the following characters `a-zA-Z0-9.-`, if there are other important ones let me know
We can also allow certain syntax such as `([a-zA-Z0-9]+\.?)+` to force IP/domain like input

### Before
<details>
<summary>Click me</summary>

![image](https://user-images.githubusercontent.com/20037329/229352248-4be04f37-b398-4060-8451-8d79d88f19ea.png)
</details>

### After
<details>
 <summary>Click me</summary>

![image](https://user-images.githubusercontent.com/20037329/229352291-8bcd6a46-4729-49c6-96f3-3c5447779cac.png)
</details>

Related issue: 
- #131