### PR TITLE
Add FreeBSD version netcat listener

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -548,6 +548,7 @@ const rsgData = {
 
     listenerCommands: [
         ['nc', 'nc -lvnp {port}'],
+        ['nc freebsd', 'nc -lvn {port}'],
 	['busybox nc', 'busybox nc -lp {port}'],
         ['ncat', 'ncat -lvnp {port}'],
         ['ncat.exe', 'ncat.exe -lvnp {port}'],


### PR DESCRIPTION
FreeBSD man page says:
```
-l	     Used to specify that nc should listen for an incoming connection
	     rather than initiate a connection to a remote host.  It is	an er-
	     ror to use	this option in conjunction with	the -p,	-s, or -z op-
	     tions.  Additionally, any timeouts	specified with the -w option
	     are ignored.
```
So, on default FreeBSD version of netcat (`/usr/bin/nc`) works only: `nc -lvn <port>`.