### PR TITLE
Update searchbar to work in all tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,27 +207,10 @@
             <div class="tab-pane active" id="reverse" role="tabpanel" aria-labelledby="reverse-tab">
                 <div class="card shadow mb-5">
                     <div class="card-body">
-
-                        <!-- Show all advanced switch -->
-                        <div class="custom-control custom-switch float-right">
-                            <input id="revshell-advanced-switch" type="checkbox" class="custom-control-input" checked>
-                            <label for="revshell-advanced-switch" class="custom-control-label small pr-2 pb-1"
-                                style="padding-top:2px" data-toggle="tooltip" title="Display all advanced settings">
-                                Show Advanced
-                            </label>
-                            <img src="assets/floppy-disk-solid.svg" class="download-svg" data-toggle="tooltip" title="Download Payload">
-                        </div>
-                        <!-- /Show all advanced switch -->
-                        <!-- Search Box -->
-                        <div class="row">
-                            <div class="col-md-6">
-                                <input type="text" id="searchBox" placeholder="Search..." class="form-control mb-3">
-                            </div>
-                        </div>
-						<!-- /Search Box -->
-                        <!---Filter OS-->
-                        <div class="row">
-                            <label for="os-options" class="col-auto col-form-label float-left"
+                        <!-- Top configuration bar -->
+                        <div class="d-md-flex">
+                            <!---Filters-->
+                            <label for="os-options" class="col-auto col-form-label"
                                 style="font-size:1rem">OS</label>
                             <div class="col-auto">
                                 <select id="os-options" class="custom-select">
@@ -237,8 +220,25 @@
                                     <option class="os-item" value="mac">Mac</option>
                                 </select>
                             </div>
+
+                            <label for="os-options" class="col-auto col-form-label"
+                                style="font-size:1rem">Name</label>
+                            <div class="col-auto flex-grow-1">
+                                <input type="text" id="searchBox" placeholder="Search..." class="form-control form-control-md text-left">
+                            </div>
+                            <!---/Filters-->
+
+                            <!-- Show all advanced switch -->
+                            <div class="custom-control custom-switch text-right d-flex justify-content-center align-self-center">
+                                <input id="revshell-advanced-switch" type="checkbox" class="custom-control-input" checked>
+                                <label for="revshell-advanced-switch" class="custom-control-label small pr-2 pb-1"
+                                    style="padding-top:2px" data-toggle="tooltip" title="Display all advanced settings">
+                                    Show Advanced
+                                </label>
+                                <img src="assets/floppy-disk-solid.svg" class="download-svg" data-toggle="tooltip" title="Download Payload">
+                            </div>
+                            <!-- /Show all advanced switch -->
                         </div>
-                        <!---/Filter OS-->
 
                         <div class="card-text mt-4">
                             <div class="row">
@@ -351,7 +351,6 @@
             <div class="tab-pane" id="bind" role="tabpanel" aria-labelledby="bind-tab">
                 <div class="card shadow mb-5">
                     <div class="card-body">
-                        <img src="assets/floppy-disk-solid.svg" class="download-svg float-right" data-toggle="tooltip" title="Download Payload">
                         <div class="card-text mt-4">
                             <div class="row">
                                 <!-- Left column: Bind selection -->
@@ -465,7 +464,6 @@
             <div class="tab-pane" id="hoaxshell" role="tabpanel" aria-labelledby="hoaxshell-tab">
                 <div class="card shadow mb-5">
                     <div class="card-body">
-                        <img src="assets/floppy-disk-solid.svg" class="download-svg float-right" data-toggle="tooltip" title="Download Payload">
                         <div class="card-text mt-4">
                             <div class="row">
                                     <!-- Left column: HoaxShell selection -->

--- a/index.html
+++ b/index.html
@@ -202,44 +202,44 @@
             </li> -->
         </ul>
 
-        <div class="tab-content">
-            <!-- Reverse Shell Tab-->
-            <div class="tab-pane active" id="reverse" role="tabpanel" aria-labelledby="reverse-tab">
-                <div class="card shadow mb-5">
-                    <div class="card-body">
-                        <!-- Top configuration bar -->
-                        <div class="d-md-flex">
-                            <!---Filters-->
-                            <label for="os-options" class="col-auto col-form-label"
-                                style="font-size:1rem">OS</label>
-                            <div class="col-auto">
-                                <select id="os-options" class="custom-select">
-                                    <option class="os-item" value="all">All</option>
-                                    <option class="os-item" value="linux">Linux</option>
-                                    <option class="os-item" value="windows">Windows</option>
-                                    <option class="os-item" value="mac">Mac</option>
-                                </select>
-                            </div>
+        <div class="card shadow mb-5">
+            <div class="card-body">
+                <!-- Top configuration bar -->
+                <div class="d-md-flex">
+                    <!---Filters-->
+                    <label for="os-options" class="col-auto col-form-label"
+                        style="font-size:1rem">OS</label>
+                    <div class="col-auto">
+                        <select id="os-options" class="custom-select">
+                            <option class="os-item" value="all">All</option>
+                            <option class="os-item" value="linux">Linux</option>
+                            <option class="os-item" value="windows">Windows</option>
+                            <option class="os-item" value="mac">Mac</option>
+                        </select>
+                    </div>
 
-                            <label for="os-options" class="col-auto col-form-label"
-                                style="font-size:1rem">Name</label>
-                            <div class="col-auto flex-grow-1">
-                                <input type="text" id="searchBox" placeholder="Search..." class="form-control form-control-md text-left">
-                            </div>
-                            <!---/Filters-->
+                    <label for="os-options" class="col-auto col-form-label"
+                        style="font-size:1rem">Name</label>
+                    <div class="col-auto flex-grow-1">
+                        <input type="text" id="searchBox" placeholder="Search..." class="form-control form-control-md text-left">
+                    </div>
+                    <!---/Filters-->
 
-                            <!-- Show all advanced switch -->
-                            <div class="custom-control custom-switch text-right d-flex justify-content-center align-self-center">
-                                <input id="revshell-advanced-switch" type="checkbox" class="custom-control-input" checked>
-                                <label for="revshell-advanced-switch" class="custom-control-label small pr-2 pb-1"
-                                    style="padding-top:2px" data-toggle="tooltip" title="Display all advanced settings">
-                                    Show Advanced
-                                </label>
-                                <img src="assets/floppy-disk-solid.svg" class="download-svg" data-toggle="tooltip" title="Download Payload">
-                            </div>
-                            <!-- /Show all advanced switch -->
-                        </div>
+                    <!-- Show all advanced switch -->
+                    <div class="custom-control custom-switch text-right d-flex justify-content-center align-self-center">
+                        <input id="revshell-advanced-switch" type="checkbox" class="custom-control-input" checked>
+                        <label for="revshell-advanced-switch" class="custom-control-label small pr-2 pb-1"
+                            style="padding-top:2px" data-toggle="tooltip" title="Display all advanced settings">
+                            Show Advanced
+                        </label>
+                        <img src="assets/floppy-disk-solid.svg" class="download-svg" data-toggle="tooltip" title="Download Payload">
+                    </div>
+                    <!-- /Show all advanced switch -->
+                </div>
 
+                <div class="tab-content">
+                    <!-- Reverse Shell Tab-->
+                    <div class="tab-pane active" id="reverse" role="tabpanel" aria-labelledby="reverse-tab">
                         <div class="card-text mt-4">
                             <div class="row">
 
@@ -340,17 +340,11 @@
 
                             </div>
                         </div>
-                        <!-- /card-text -->
-
                     </div>
-                </div>
-            </div>
-            <!-- /Reverse Shell Tab -->
+                    <!-- /Reverse Shell Tab -->
 
-            <!-- Bind Shell Tab -->
-            <div class="tab-pane" id="bind" role="tabpanel" aria-labelledby="bind-tab">
-                <div class="card shadow mb-5">
-                    <div class="card-body">
+                    <!-- Bind Shell Tab -->
+                    <div class="tab-pane" id="bind" role="tabpanel" aria-labelledby="bind-tab">
                         <div class="card-text mt-4">
                             <div class="row">
                                 <!-- Left column: Bind selection -->
@@ -395,15 +389,10 @@
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-            <!-- /Bind Shell Tab -->
+                    <!-- /Bind Shell Tab -->
 
-            <!-- MSFVenom Tab -->
-            <div class="tab-pane" id="msfvenom" role="tabpanel" aria-labelledby="msfvenom-tab">
-                <div class="card shadow mb-5">
-                    <div class="card-body">
-                        <img src="assets/floppy-disk-solid.svg" class="download-svg float-right" data-toggle="tooltip" title="Download Payload">
+                    <!-- MSFVenom Tab -->
+                    <div class="tab-pane" id="msfvenom" role="tabpanel" aria-labelledby="msfvenom-tab">
                         <div class="card-text mt-4">
                             <div class="row">
                                     <!-- Left column: MSFVenom selection -->
@@ -456,14 +445,10 @@
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-            <!-- /MSFVenom Tab -->
+                    <!-- /MSFVenom Tab -->
 
-            <!-- HoaxShell Tab -->
-            <div class="tab-pane" id="hoaxshell" role="tabpanel" aria-labelledby="hoaxshell-tab">
-                <div class="card shadow mb-5">
-                    <div class="card-body">
+                    <!-- HoaxShell Tab -->
+                    <div class="tab-pane" id="hoaxshell" role="tabpanel" aria-labelledby="hoaxshell-tab">
                         <div class="card-text mt-4">
                             <div class="row">
                                     <!-- Left column: HoaxShell selection -->
@@ -507,10 +492,10 @@
                             </div>
                         </div>
                     </div>
+                    <!-- /hoaxshell Tab -->
                 </div>
             </div>
-            <!-- /hoaxshell Tab -->
-    </div>
+        </div>
 
     <!-- RSG data -->
     <script src="js/data.js"></script>

--- a/js/script.js
+++ b/js/script.js
@@ -358,7 +358,14 @@ const rsg = {
             }
         );
 
-        const documentFragment = document.createDocumentFragment()
+        const documentFragment = document.createDocumentFragment();
+        if (filteredItems.length === 0) {
+            const emptyMessage = document.createElement("button");
+            emptyMessage.innerText = "No results found";
+            emptyMessage.classList.add("list-group-item", "list-group-item-action", "disabled");
+
+            documentFragment.appendChild(emptyMessage);
+        }
         filteredItems.forEach((item, index) => {
             const {
                 name,


### PR DESCRIPTION
Changes made:

- Fix existing search styling issues
- Fix edgecases with existing search functionality, i.e. changing port breaks the previously applied search filter
- Fix a bug where the operating system filter didn't work across refreshes
- Each tab now has the search filter present
- When a search has no results, the user is now notified
- Improved mobile size viewing for the search functionality
- Add support for the filter to work via URL - i.e. http://localhost:8000/#filterOperatingSystem=linux&filterText=abc

### Empty results

The user is notified when no results are found:

<img width="1198" alt="image" src="https://github.com/0dayCTF/reverse-shell-generator/assets/1271782/016d50a8-7039-42c6-8f0c-f0bed983b610">

### Finding results

Search styles improved, and search functionality now available on all tabs:

<img width="1191" alt="image" src="https://github.com/0dayCTF/reverse-shell-generator/assets/1271782/2383d6f9-6d5f-4b51-a825-3de3837babac">


### Smaller displays

Search functionality for the search ba rnow rendered better for mobile size viewing, although the mobile viewing for the rest of the site still is not super great:

<img width="606" alt="image" src="https://github.com/0dayCTF/reverse-shell-generator/assets/1271782/e0dc6d33-8afd-4db7-b1d2-23e3efcdec88">