### PR TITLE
Fixed Small-Device View

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,17 @@
                 fill="currentColor" class="octo-body"></path>
         </svg></a>
     <style>
+        @media (max-width: 767px) {
+            #reverse-shell-selection {
+                max-height: 290px;
+            }
+        }
+
+        @media (min-width: 768px) {
+            #reverse-shell-selection {
+                max-height: 520px;
+            }
+        }
     </style>
 </head>
 
@@ -245,8 +256,7 @@
 
                                 <!-- Left column: Reverse shell selection -->
                                 <div class="col-12 col-md-3">
-                                    <div id="reverse-shell-selection" class="list-group overflow-auto"
-                                        style="max-height: 490px">
+                                    <div id="reverse-shell-selection" class="list-group overflow-auto">
                                         <!-- filled by init()-->
                                     </div>
                                 </div>


### PR DESCRIPTION
fixed issue #163 
Fixed CSS so that max width decreases for small devices which prevents overflow of div(content).

Here is an image of fixed version::
![image](https://github.com/0dayCTF/reverse-shell-generator/assets/138952788/d98482b6-83a7-40ee-ab62-a24bab023c84)
