### PR TITLE
Replace uhttpd with nginx:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM fnichol/uhttpd
+FROM nginx:alpine
 
-COPY . /www
+COPY . /usr/share/nginx/html/


### PR DESCRIPTION
Fixes #181 

Path updated to reflect the default folder in the nginx build.

