### PR TITLE
Add: export payloads to .txt based on current IP, port, and OS values

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,6 +343,8 @@
                                             title="Copy to clipboard" type="button" class="btn btn-primary float-right">
                                             Copy
                                         </button>
+
+                                        <button id="download-reverse-shell-btn" class="btn btn-primary float-right ml-3">Export to .txt</button>
                                     </div>
 
                                 </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,3 @@
-
 // Element selectors
 const ipInput = document.querySelector("#ip");
 const portInput = document.querySelector("#port");
@@ -443,7 +442,35 @@ const rsg = {
             'hide')
         $('#revshell-advanced').collapse($('#revshell-advanced-switch').prop('checked') ? 'show' :
             'hide')
-    }
+    },
+
+    exportPayloadsToTxt: () => {
+        // Generate reverse shell payloads in .txt
+        // Can be used with Burp Intrudeer
+        const payloads = [];
+        const reverseShellItems = document.querySelectorAll("#reverse-shell-selection .list-group-item");
+    
+        reverseShellItems.forEach(item => {
+            const commandName = item.innerText;
+            const commandData = rsgData.reverseShellCommands.find(cmd => cmd.name === commandName);
+            if (commandData && commandData.command) {
+                const command = rsg.insertParameters(commandData.command, (text) => text);
+                // skip multi-row commands or scripts
+                if (!command.includes('\n')) {
+                    payloads.push(command);
+                }
+            }
+        });
+    
+        const fileContent = payloads.join('\n');
+        const blob = new Blob([fileContent], { type: 'text/plain' });
+    
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = 'reverse_shell_payloads.txt';
+        link.click();
+        URL.revokeObjectURL(link.href);
+    },
 }
 
 /*
@@ -522,6 +549,8 @@ document.querySelector('#copy-msfvenom-command').addEventListener('click', () =>
 document.querySelector('#copy-hoaxshell-command').addEventListener('click', () => {
     rsg.copyToClipboard(hoaxShellCommand.innerText)
 })
+
+document.querySelector('#download-reverse-shell-btn').addEventListener('click', rsg.exportPayloadsToTxt);
 
 var downloadButton = document.querySelectorAll(".download-svg");
 for (const Dbutton of downloadButton) {


### PR DESCRIPTION
Thank you for this cool repository. It has been incredibly helpful for my studies.

I saw an opportunity to add a feature that I believe could be useful for others as well. This feature allows users to export reverse shell payloads to a .txt file based on the current IP, port, and OS values. It’s particularly useful in CTFs, where you often need to test multiple payloads to find the one that works, and using this with tools like Burp Intruder can save a lot of time.

To make it more practical, I eliminated multi-line payloads and kept only one-liners for simplicity and compatibility. I hope the author and the community will find this addition as useful as I do.

Thank you again for maintaining this awesome project! I am open for suggestions regarding this PR.