### PR TITLE
add button to download all filtered shells

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,6 +244,9 @@
                             Show Advanced
                         </label>
                         <img src="assets/floppy-disk-solid.svg" class="download-svg" data-toggle="tooltip" title="Download Payload">
+                        <button type="button" class="btn btn-sm btn-secondary ml-2" id="download-all-shells" data-toggle="tooltip" title="Download All Filtered Shells">
+                            Download All
+                        </button>
                     </div>
                     <!-- /Show all advanced switch -->
                 </div>

--- a/js/script.js
+++ b/js/script.js
@@ -166,6 +166,45 @@ const rsg = {
         }
     },
 
+    downloadAllShells: () => {
+        const filteredItems = filterCommandData(
+            rsgData.reverseShellCommands,
+            {
+                filterOperatingSystem: rsg.filterOperatingSystem,
+                filterText: rsg.filterText,
+                commandType: rsg.commandType
+            }
+        );
+
+        if (filteredItems.length === 0) {
+            return;
+        }
+
+        let content = '';
+
+        filteredItems.forEach((item, index) => {
+            const tempSelectedValue = rsg.selectedValues[rsg.commandType];
+            rsg.selectedValues[rsg.commandType] = item.name;
+            const command = rsg.insertParameters(item.command, (text) => text);
+            rsg.selectedValues[rsg.commandType] = tempSelectedValue;
+            
+            content += command;
+            if (index < filteredItems.length - 1) {
+                content += '\n-----\n';
+            }
+        });
+
+        const blob = new Blob([content], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `reverse-shells-${rsg.filterOperatingSystem}-${rsg.commandType}.txt`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    },
+
     escapeHTML: (text) => {
         let element = document.createElement('p');
         element.textContent = text;
@@ -544,6 +583,11 @@ for (const Dbutton of downloadButton) {
         });
     });
 }
+
+// Add event listener for download all shells button
+document.getElementById("download-all-shells").addEventListener("click", () => {
+    rsg.downloadAllShells();
+});
 
 // autoCopySwitch.addEventListener("change", () => {
 //     setLocalStorage(autoCopySwitch, "auto-copy", "checked");


### PR DESCRIPTION
A new button that can be used to download all filtered shells into a .txt file. The payloads are delimited using an arbitrary delimiter (in this case "-----") so it should be easy to parse them if using the file in another context.