### PR TITLE
Replace deprecated fnichol/uhttpd base image with nginx:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
-FROM fnichol/uhttpd
-
-COPY . /www
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80
+# nginx base image provides the default CMD


### PR DESCRIPTION
fix(docker): replace fnichol/uhttpd with nginx:alpine

The old fnichol/uhttpd image is no longer available because it relied on
the deprecated Docker schema v1 manifest. Switched to nginx:alpine,
which is lightweight, maintained, and serves static content from
/usr/share/nginx/html by default.

This change resolves build failures while preserving the original
behavior of serving project files over port 80.
